### PR TITLE
[rust]: Support including disambiguating hashes in demangled symbols

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,30 +4,30 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -36,15 +36,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustfilt"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.4.0"
 regex = "1.5.5"
-rustc-demangle = "0.1.20"
+rustc-demangle = "0.1.24"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -8,13 +8,18 @@ use rustc_demangle::demangle;
 use std::io;
 use std::io::prelude::*;
 
-fn demangle_line(line: &str) -> String {
+fn demangle_line(no_verbose: bool, line: &str) -> String {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"[_a-zA-Z$][_a-zA-Z$0-9.]*").unwrap();
     }
 
     RE.replace_all(line, |caps: &Captures<'_>| {
-        format!("{:#}", demangle(caps.get(0).unwrap().as_str()))
+        let demangled = demangle(caps.get(0).unwrap().as_str());
+        if no_verbose {
+            format!("{:#}", demangled)
+        } else {
+            format!("{}", demangled)
+        }
     })
     .to_string()
 }
@@ -26,7 +31,7 @@ mod tests {
     #[test]
     fn passes_text() {
         assert_eq!(
-            demangle_line("mo fo\tboom      hello  "),
+            demangle_line(true, "mo fo\tboom      hello  "),
             "mo fo\tboom      hello  "
         );
     }
@@ -34,7 +39,7 @@ mod tests {
     #[test]
     fn demangles() {
         assert_eq!(
-            demangle_line("_ZN7example4main17h0db00b8b32acffd5E:"),
+            demangle_line(true, "_ZN7example4main17h0db00b8b32acffd5E:"),
             "example::main:"
         );
     }
@@ -42,7 +47,7 @@ mod tests {
     #[test]
     fn handles_mid_demangling() {
         assert_eq!(
-            demangle_line("        lea     rax, [rip + _ZN55_$LT$$RF$$u27$a$u20$T$u20$as$u20$core..fmt..Display$GT$3fmt17h510ed05e72307174E]"),
+            demangle_line(true, "        lea     rax, [rip + _ZN55_$LT$$RF$$u27$a$u20$T$u20$as$u20$core..fmt..Display$GT$3fmt17h510ed05e72307174E]"),
                 "        lea     rax, [rip + <&\'a T as core::fmt::Display>::fmt]",
         );
     }
@@ -50,16 +55,45 @@ mod tests {
     #[test]
     fn handles_call_plt() {
         assert_eq!(
-            demangle_line("        call    _ZN3std2io5stdio6_print17he48522be5b0a80d9E@PLT"),
+            demangle_line(true, "        call    _ZN3std2io5stdio6_print17he48522be5b0a80d9E@PLT"),
             "        call    std::io::stdio::_print@PLT"
+        );
+    }
+
+    #[test]
+    fn includes_hash_in_verbose_mode() {
+        assert_eq!(
+            demangle_line(false, "_ZN4core3fmt9Arguments9new_const17hf7eafdf6c5e03508E"),
+            "core::fmt::Arguments::new_const::hf7eafdf6c5e03508",
+        );
+    }
+
+    #[test]
+    fn demangles_v0_symbols() {
+        assert_eq!(
+            demangle_line(true, "_RNvCslMLAjg8TrSC_7example4meow"),
+            "example::meow",
+        );
+    }
+
+    #[test]
+    fn demangles_double_underscore_prefixed_symbols() {
+        assert_eq!(
+            demangle_line(true, "__RINvMs2_NtCslVVlGMZyABT_4core3fmtNtB6_9Arguments9new_constKj1_ECslMLAjg8TrSC_7example"),
+            "<core::fmt::Arguments>::new_const::<1>",
+        );
+        assert_eq!(
+            demangle_line(true, "__ZN4core3fmt9Arguments9new_const17hf7eafdf6c5e03508E"),
+            "core::fmt::Arguments::new_const",
         );
     }
 }
 
 fn main() {
+    let no_verbose = std::env::args().any(|arg| arg == "--no-verbose");
     let stdin = io::stdin();
 
     for line in stdin.lock().lines() {
-        println!("{}", demangle_line(&line.unwrap()));
+        println!("{}", demangle_line(no_verbose, &line.unwrap()));
     }
 }


### PR DESCRIPTION
`c++filt` can’t demangle Rust symbols for some platforms (at least 32-bit Windows and any Apple platform), so this PR adds `--no-verbose` so that `rustfilt` can replace `c++filt` for Rust.

See https://github.com/compiler-explorer/compiler-explorer/issues/7772.