### PR TITLE
Update `rustc-demangle`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustfilt"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.4.0"
 regex = "1.5.5"
-rustc-demangle = "0.1.24"
+rustc-demangle = "0.1.27"


### PR DESCRIPTION
`rustc` nightly [now defaults](https://github.com/rust-lang/rust/pull/89917) to the `v0` name mangling scheme, and the current `rustc-demangle` doesn’t support [pattern types with `v0`](https://github.com/rust-lang/rustc-demangle/commit/2fb651dc5f933733730e92cb134f0b8d8f2038b8).